### PR TITLE
Add NAPS-based alignment

### DIFF
--- a/example_preprocessing.qmd
+++ b/example_preprocessing.qmd
@@ -32,6 +32,12 @@ library(MetaboCoreUtils)
 library(MetaboAnnotation)
 ```
 
+In case one or more of the above libraries are not available (and hence fail to
+load), they can be installed with the R command `BiocManager::install()`
+(e.g. `BiocManager::install("alabaster.base")` to install the *alabaster.base* R
+package). Note that this requires the installation of the *BiocManager* R
+package (which can be installed with `install.packages("BiocManager")`).
+
 ## Load metadata and raw files
 
 ```{r}
@@ -59,7 +65,7 @@ seq <- rbind(seq_pos, seq_neg)
 
 seq$filename <- paste0(seq$`Data File`, ".mzML")
 mse <- readMsExperiment(paste0("data/", lab,"/HE_mzml/", seq$filename), 
-                            seq)
+                        seq)
 sampleData(mse)
 ```
 
@@ -99,6 +105,7 @@ names(col_sample_type)[seq_along(unique(sampleData(mse_pos)$sample_type))] <-
     unique(sampleData(mse_pos)$sample_type)
 bpc_pos <- chromatogram(mse_pos, aggregationFun = "max")
 bpc_neg <- chromatogram(mse_neg, aggregationFun = "max")
+bpc <- chromatogram(mse, aggregationFun = "max", chromPeaks = "none")
 
 xl <- range(unlist(lapply(bpc_pos, rtime)), unlist(lapply(bpc_neg, rtime)))
 yl <- max(unlist(lapply(bpc_pos, intensity)),
@@ -276,8 +283,7 @@ Comment:
 cwp <- CentWaveParam(peakwidth = c(4, 12), ppm = 20, integrate = 2,
                      snthresh = 7, noise = 100) 
 
-mse <- findChromPeaks(mse, cwp, 
-                          msLevel = 1L, chunkSize = 2L)
+mse <- findChromPeaks(mse, cwp, msLevel = 1L, chunkSize = 2L)
 
 mnpp <- MergeNeighboringPeaksParam(expandRt = 6, expandMz = 0.0015,
                                    minProp = 0.75)
@@ -302,6 +308,160 @@ We saw above that there does not seem to be a big shift in retention time
 between the samples. We will nonetheless align the samples using the NAPS
 samples. Considering them as a repetiting samples that should represent
 potential rt shift during the injection runtime.
+
+The NAPS-based alignment will use the retention times of the NAPS compounds to
+align the data sets (also positive and negative polarity) against each other. We
+thus identify (separately for each polarity) chromatographic peaks matching the
+m/z of NAPS adducts. If multiple chromatographic peaks are matched to a NAPS in
+one sample we select the peak with the highest intensity. Also, we require the
+retention times of the NAPS within one sample to be increasingly ordered.
+
+Note: this approach seemed to work well - but we might need to adapt it for data
+sets in which we e.g. can not identify chromatographic peaks for most NAPS or if
+their retention times are not increasingly ordered.
+
+Below we load the NAPS information and perform the analysis for the positive
+polarity data.
+
+```{r}
+#' loading info from NAPS 
+naps_info <- read_xlsx("NAPS_info.xlsx", .name_repair = "minimal") |>
+    as.data.frame()
+
+#' calculate m/z 
+naps_info$mz_pos <- mass2mz(naps_info$`exact mass`, adduct = "[M+H]+")[, 1]
+
+#' subset positive polarity
+naps_pos <- mse[sampleData(mse)[, "Sample.Name"] == "NAPS" &
+                sampleData(mse)[, "polarity"] == "pos"]
+
+#' Match chromatographic peaks against NAPS
+cpks <- chromPeaks(naps_pos)
+naps_pos_match <- matchValues(cpks, naps_info, mzColname = c("mz", "mz_pos"),
+                              MzParam(tolerance = 0, ppm = 10))
+naps_pos_match <- naps_pos_match[whichQuery(naps_pos_match)]
+md <- matchedData(naps_pos_match, c("mz", "rt", "maxo", "sample",
+                                    "ppm_error", "target_Name")) |>
+    as.data.frame()
+
+#' Helper function to extract a retention time matrix from the `matchedData`
+#' `data.frame`. The function simply iterates over the sample and extracts the
+#' retentio time for each chrom peak matching a NAPS. If multiple chrom peaks
+#' match a NAPS, the one with the highest intensity (`"maxo"`) is selected.
+#' The function throws an error if the extracted retention times in one sample
+#' are not ordered increasingly.
+#'
+#' @param x `data.frame` with at least columns `"rt"`, `"maxo"`, `"sample"`
+#'     and `"target_Name"`
+#'
+#' @param naps_info `data.frame` with NAPS information. Needs to have a column
+#'     `"Name"` with the name of the NAPS and with the data odered increasingly
+#'     by retention time.
+#' 
+#' @return `matrix` with retention times of the NAPS in the individual samples.
+#'     Columns are samples and rows NAPS.
+naps_rt_matrix <- function(x, naps_info) {
+    smpls <- unique(x[, "sample"])
+    res <- matrix(NA_real_, ncol = length(smpls), nrow = nrow(naps_info))
+    rownames(res) <- naps_info$Name
+    for (i in smpls) {
+        z <- x[x$sample == i, ]
+        rti <- split(z, factor(z$target_Name, naps_info$Name))
+        rti <- do.call(
+            rbind,
+            lapply(rti, function(z) z[which.max(z$maxo), , drop = FALSE]))
+        if (is.unsorted(rti$rt))
+            stop("Retention times are not increasingly ordered for sample ", i)
+        res[match(rownames(rti), rownames(res)), i] <- rti$rt
+    }
+    res
+}
+
+pos_rt_matrix <- naps_rt_matrix(md, naps_info)
+```
+
+We repeat for negative polarity.
+
+```{r}
+#' Define m/z for the expected ions of the NAPS
+naps_info$mz_neg <- mass2mz(naps_info$`exact mass`, adduct = "[M-H]-")[, 1]
+
+#' Negative polarity
+naps_neg <- mse[sampleData(mse)[, "Sample.Name"] == "NAPS" &
+                sampleData(mse)[, "polarity"] == "neg"]
+cpks <- chromPeaks(naps_neg)
+naps_neg_match <- matchValues(cpks, naps_info, mzColname = c("mz", "mz_neg"),
+                              MzParam(tolerance = 0, ppm = 10))
+naps_neg_match <- naps_neg_match[whichQuery(naps_neg_match)]
+md <- matchedData(naps_neg_match, c("mz", "rt", "maxo", "sample",
+                                    "ppm_error", "target_Name")) |>
+    as.data.frame()
+
+neg_rt_matrix <- naps_rt_matrix(md, naps_info)
+    matchedData(naps_neg_match, c("rt", "maxo", "sample", "target_Name")),
+```
+
+We next combine the retention time matrices for positive and negative polarity.
+
+```{r}
+rt_matrix <- cbind(pos_rt_matrix, neg_rt_matrix)
+```
+
+We use this retention time matrix for the alignment. Note that for `subsetAdjust
+= "average"` it is highly recommended that the first and last measurement for
+positive as well as for negative polarity are for NAPS samples. Also, the
+samples should be in the order they were measured.
+
+```{r}
+pgp <- PeakGroupsParam(
+    minFraction = 0.75,
+    extraPeaks = 50,
+    span = 0.5,
+    subset = which(sampleData(mse)$sample_type == "NAPS"),
+    subsetAdjust = "average",
+    peakGroupsMatrix = rt_matrix)
+mse_adj <- adjustRtime(mse, param = pgp)
+```
+
+```{r}
+plotAdjustedRtime(
+    mse_adj, col = paste0(col_sample_type[sampleData(mse_adj)$sample_type], 60))
+```
+
+WHY don't we have smooth lines???
+
+```{r}
+#' Ideally, we want to validate that alignment improved the data.
+
+bpc_adj <- chromatogram(mse_adj, aggregationFun = "max", chromPeaks = "none")
+
+bs <- floor(diff(range(rtime(mse))) / 50)
+bpc_b <- bin(bpc, binSize = bs)
+bpc_adj_b <- bin(bpc_adj, binSize = bs)
+
+#' Create a log2 transformed, column centered intensity matrix
+bpc_m <- lapply(bpc_b, intensity) |>
+    do.call(what = rbind) |>
+    log2() |>
+    scale(center = TRUE, scale = FALSE)
+colnames(bpc_m) <- rtime(bpc_b[1, 1])
+rownames(bpc_m) <- sampleData(mse)$Sample.Name
+
+#' Same for BPC after alignment
+bpc_adj_m <- lapply(bpc_adj_b, intensity) |>
+    do.call(what = rbind) |>
+    log2() |>
+    scale(center = TRUE, scale = FALSE)
+colnames(bpc_adj_m) <- rtime(bpc_adj_b[1, 1])
+rownames(bpc_adj_m) <- sampleData(mse)$Sample.Name
+```
+
+```{r}
+#' Plot the BPC heatmaps; no big difference can be seen.
+pheatmap(bpc_m, cluster_cols = FALSE)
+pheatmap(bpc_adj_m, cluster_cols = FALSE)
+```
+
 
 ```{r}
 ## Correspondence - for alignment


### PR DESCRIPTION
This PR adds some code to

- identify chrom peaks within each (NAPS) sample for each NAPS
- extract the retention time matrix with the RT of these
- perform the alignment using this provided RT matrix
- assess the alignment result

What I am a bit puzzled is the `plotAdjustedRtime()` plot - the individual lines for the samples don't look smooth - I might need to check into *xcms* to see why that is happening.